### PR TITLE
adjusted profile so depending on booking/booked you see different inf…

### DIFF
--- a/app/views/bookings/profile.html.erb
+++ b/app/views/bookings/profile.html.erb
@@ -10,6 +10,11 @@
     </div>
     <%# booking cards by renter %>
     <div class="my-5 col-lg-8 col-12">
+      <% if @bookings.empty? %>
+      <h3 class="text-center mb-5 border-bottom pb-5">No Bookings Yet!
+        <%= link_to "Browse Dresses", dresses_path, class: 'card-link' %>
+      </h3>
+      <% else %>
       <h3 class="text-center">Current Bookings</h3>
       <div class="row booking-info justify-content-center">
         <% @bookings.each do |booking| %>
@@ -29,9 +34,10 @@
           </div>
         </div>
         <% end %>
+        <% end %>
         <%# booking cards awaiting confirmation - owner %>
         <div class="container">
-          <% if @booked %>
+          <% if @booked.present? %>
             <h3 class="text-center">Booking Requests</h3>
             <div class="row booking-info justify-content-center">
               <% @booked.each do |booking| %>
@@ -70,6 +76,6 @@
         </div>
       </div>
     </div>
+  <%= link_to 'See All Bookings', bookings_path, class: 'btn btn-outline-secondary float-right mb-3 inline-block' %>
   </div>
-  <%= link_to 'See All Bookings', bookings_path, class: 'btn btn-outline-secondary float-right mb-3' %>
 </div>


### PR DESCRIPTION
Depending on whether you booked or had your dress booked (or have nothing at all yet) then the profile will change 
<img width="1053" alt="Screen Shot 2022-01-31 at 14 30 39" src="https://user-images.githubusercontent.com/86721807/151744010-86a67196-971c-4827-acaa-e4bcf0cc0e22.png">
<img width="1237" alt="Screen Shot 2022-01-31 at 14 32 08" src="https://user-images.githubusercontent.com/86721807/151744032-6b3ecb69-6e12-4f85-843e-a037ef49c6b6.png">

The Headers for Current Bookings and Booking Requests will only appear if there are actually bookings/booking requests! If no bookings, there is a link to browse dresses on the index page
