### PR TITLE
Removed a line that was a doubled up link to the add dress form

### DIFF
--- a/app/views/dresses/listings.html.erb
+++ b/app/views/dresses/listings.html.erb
@@ -1,11 +1,10 @@
 <div class="container">
   <h2 class="my-3">Your Listings</h2>
-  <h3>
+  <p>
     <% if @dresses.count == 0 %>
       No listings yet!
-      <%= link_to 'Add a new dress?', new_dress_path, class: 'card-link' %>
     <% end %>
-  </h3>
+  </p>
   <%# <% @dresses.count > 1 ? @dresses.count dresses :
      @dresses.count dress %>
   <div class="row justify-content-center">


### PR DESCRIPTION
Made it a little nicer(?) Changed the "No listing yet!" from H3 to P and I removed the Add a Dress link that we had next to that since we have the same button on the bottom right.

Lemme know if you want it changed back or to something else.

<img width="1348" alt="Screen Shot 2022-02-05 at 9 39 21" src="https://user-images.githubusercontent.com/89627682/152621388-4e265a2c-4443-414d-b356-a21f7da4e962.png">
