### PR TITLE
removed fade effect on swiper

### DIFF
--- a/app/javascript/plugins/swiper.js
+++ b/app/javascript/plugins/swiper.js
@@ -4,8 +4,8 @@ const initSwiper = () => {
   if (swiper_present) {
     new Swiper(".mySwiper", {
       spaceBetween: 30,
-      effect: "fade",
-      // slidesPerView: "auto",
+      // effect: "fade",
+      slidesPerView: "auto",
       // If not using fade and having regular slide effect, set slidesPerView to "auto" to have it centered after navigating multiple pictures
       centeredSlides: true,
       loop: true,


### PR DESCRIPTION
Removed the fade effect in swiper, as you can see as the photos loop through its like the stack up on each other.

As Gary wrote, I changed it to the slides per view auto so that they keep their position when playing.

<img width="935" alt="Screen Shot 2022-02-05 at 10 05 56" src="https://user-images.githubusercontent.com/89627682/152622765-08db2b6d-7bb0-4f6d-ae97-a52d08b9f4ff.png">
